### PR TITLE
Set IFS as local var in autocompletion

### DIFF
--- a/.github/scripts/update_autocompletion.sh
+++ b/.github/scripts/update_autocompletion.sh
@@ -67,6 +67,7 @@ EOF
 
   # Overwrite shebang
   sed -i '1c#!/usr/bin/env bash' "bash/${CWL_ICA_NAMEROOT}.bash"
+  sed -i 's/local prefix=""/local prefix=""\n    local IFS=\$'"'"'\\n'"'"'/' "bash/${CWL_ICA_NAMEROOT}.bash"
 
   # Secondly convert any EOF) to EOF\n) (this also needs to be repeated for zsh)
   sed -i  $'s/EOF)/EOF\\\n)/' "bash/${CWL_ICA_NAMEROOT}.bash"

--- a/autocompletion/bash/cwl-ica.bash
+++ b/autocompletion/bash/cwl-ica.bash
@@ -1242,6 +1242,7 @@ to workflow names
 
 _cwl-ica_compreply() {
     local prefix=""
+    local IFS=$'\n'
     cur="$(printf '%q' "$cur")"
     IFS=$'\n' COMPREPLY=($(compgen -P "$prefix" -W "$*" -- "$cur"))
     __ltrim_colon_completions "$prefix$cur"


### PR DESCRIPTION
Stops IFS being set in environment as just '\n' which can cause issues with other autocompletion code
 
Is a workaround for: 
* https://github.com/perlpunk/shell-completions/issues/2
* https://github.com/scop/bash-completion/issues/515