### PR TITLE
Check step lengths for workflow (and subworkflows) before zipping to v2

### DIFF
--- a/subcommands/v2/zip_v2_workflow.py
+++ b/subcommands/v2/zip_v2_workflow.py
@@ -143,7 +143,7 @@ Example:
         self.cwl_workflow_obj.validate_object()
 
         logger.info("Ensuring workflow does not have steps with names greater than 21 characters")
-        check_workflow_step_lengths(self.cwl_workflow_obj.cwl_obj)
+        check_workflow_step_lengths(self.cwl_workflow_obj.cwl_obj, self.cwl_file_path)
 
         logger.info("Zipping up workflow")
         self.zip_workflow()
@@ -240,7 +240,6 @@ Example:
 
         # Find steps in workflow.cwl and workflows/ (subworkflows)
         logger.info("Finding steps names with lengths greater than 23 characters")
-        #workflow_list = [Path(output_tempdir / "workflow.cwl")]
         workflow_list = []
         workflow_dir = Path(output_tempdir / "workflows")
         if workflow_dir.is_dir():
@@ -251,8 +250,7 @@ Example:
             cwl_repo_workflow_path = Path(get_cwl_ica_repo_path()) / workflow_item.relative_to(output_tempdir)
             workflow_name, workflow_version = get_name_version_tuple_from_cwl_file_path(cwl_repo_workflow_path, get_workflows_dir())
             workflow_object = CWLWorkflow(workflow_name, workflow_version, cwl_repo_workflow_path)
-            check_workflow_step_lengths(workflow_object.cwl_obj)
-
+            check_workflow_step_lengths(workflow_object.cwl_obj, self.cwl_file_path)
 
         # Revalidate directory with cwltool --validate
         logger.info("Now all files have been transferred, confirming successful 'zip' with cwltool --validate")

--- a/subcommands/v2/zip_v2_workflow.py
+++ b/subcommands/v2/zip_v2_workflow.py
@@ -35,7 +35,7 @@ from typing import Optional, List, Dict
 from classes.cwl_workflow import CWLWorkflow
 from utils.repo import get_workflows_dir, get_cwl_ica_repo_path
 from utils.miscell import get_name_version_tuple_from_cwl_file_path
-from utils.cwl_workflow_helper_utils import get_step_mappings, collect_objects_recursively
+from utils.cwl_workflow_helper_utils import get_step_mappings, collect_objects_recursively, check_workflow_step_lengths
 from utils.cwl_schema_helper_utils import get_schemas
 from utils.cwl_schema_helper_utils import get_schema_mappings
 from utils.subprocess_handler import run_subprocess_proc
@@ -142,6 +142,9 @@ Example:
         logger.info("Validating workflow before copying over files")
         self.cwl_workflow_obj.validate_object()
 
+        logger.info("Ensuring workflow does not have steps with names greater than 21 characters")
+        check_workflow_step_lengths(self.cwl_workflow_obj.cwl_obj)
+
         logger.info("Zipping up workflow")
         self.zip_workflow()
 
@@ -234,6 +237,22 @@ Example:
 
                     # Print line back to file
                     print(line_strip)
+
+        # Find steps in workflow.cwl and workflows/ (subworkflows)
+        logger.info("Finding steps names with lengths greater than 23 characters")
+        #workflow_list = [Path(output_tempdir / "workflow.cwl")]
+        workflow_list = []
+        workflow_dir = Path(output_tempdir / "workflows")
+        if workflow_dir.is_dir():
+            for path_item in workflow_dir.rglob("*"):
+                if path_item.is_file() and path_item.suffix == ".cwl":
+                    workflow_list.append(path_item)
+        for workflow_item in workflow_list:
+            cwl_repo_workflow_path = Path(get_cwl_ica_repo_path()) / workflow_item.relative_to(output_tempdir)
+            workflow_name, workflow_version = get_name_version_tuple_from_cwl_file_path(cwl_repo_workflow_path, get_workflows_dir())
+            workflow_object = CWLWorkflow(workflow_name, workflow_version, cwl_repo_workflow_path)
+            check_workflow_step_lengths(workflow_object.cwl_obj)
+
 
         # Revalidate directory with cwltool --validate
         logger.info("Now all files have been transferred, confirming successful 'zip' with cwltool --validate")

--- a/utils/cwl_workflow_helper_utils.py
+++ b/utils/cwl_workflow_helper_utils.py
@@ -11,11 +11,16 @@ from classes.cwl_expression import CWLExpression
 from cwl_utils.parser_v1_1 import Workflow, WorkflowStep
 from typing import Optional, Dict, List
 from pathlib import Path
+
+from utils.globals import ICAV2_MAX_STEP_CHARACTERS
 from utils.miscell import get_items_dir_from_cwl_file_path
 from utils.cwl_helper_utils import get_include_items
 from utils.cwl_schema_helper_utils import get_schemas, add_additional_schemas_to_schema_list_recursively
 from utils.miscell import get_name_version_tuple_from_cwl_file_path
 from utils.repo import join_run_path_from_caller_path, get_cwl_ica_repo_path
+from utils.logging import get_logger
+
+logger = get_logger()
 
 
 def get_step_mappings(steps: List[WorkflowStep], workflow_path: Path) -> List[Dict]:
@@ -89,4 +94,13 @@ def collect_objects_recursively(cwl_item, workflow_items: Optional[Dict] = None)
 
     return workflow_items
 
+
+def check_workflow_step_lengths(cwl_workflow: Workflow):
+    for step in cwl_workflow.steps:
+        step_name = step.id.split("#", 1)[-1].rsplit("/", 1)[-1]
+
+        if len(step_name) > ICAV2_MAX_STEP_CHARACTERS:
+            logger.warning(
+                f"Step name '{step_name}' is greater than {ICAV2_MAX_STEP_CHARACTERS} characters"
+            )
 

--- a/utils/globals.py
+++ b/utils/globals.py
@@ -181,6 +181,8 @@ BLANK_PARAMS_XML_V2_FILE_CONTENTS = [
     '</pd:pipeline>'
 ]
 
+ICAV2_MAX_STEP_CHARACTERS = 21
+
 ICAV2_DEFAULT_BASE_URL = "https://ica.illumina.com/ica/rest"
 
 

--- a/utils/globals.py
+++ b/utils/globals.py
@@ -181,7 +181,7 @@ BLANK_PARAMS_XML_V2_FILE_CONTENTS = [
     '</pd:pipeline>'
 ]
 
-ICAV2_MAX_STEP_CHARACTERS = 21
+ICAV2_MAX_STEP_CHARACTERS = 23
 
 ICAV2_DEFAULT_BASE_URL = "https://ica.illumina.com/ica/rest"
 


### PR DESCRIPTION
Zipping a workflow now throws the following warnings

```
cwl-ica icav2-zip-workflow --workflow-path workflows/bclconvert-with-qc-pipeline/4.0.3/bclconvert-with-qc-pipeline__4.0.3.cwl
2022-10-31 10:30:21,688 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/bclconvert-run-configuration/2.0.0--4.0.3/bclconvert-run-configuration__2.0.0--4.0.3.yaml" into namespaces before we import the cwl object
2022-10-31 10:30:21,760 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/fastq-list-row/1.0.0/fastq-list-row__1.0.0.yaml" into namespaces before we import the cwl object
2022-10-31 10:30:21,924 - INFO     - zip_v2_workflow           - __call__                                 : LineNo. 142  - Validating workflow before copying over files
2022-10-31 10:31:09,892 - INFO     - zip_v2_workflow           - __call__                                 : LineNo. 145  - Ensuring workflow does not have steps with names greater than 21 characters
2022-10-31 10:31:09,893 - WARNING  - cwl_workflow_helper_utils - check_workflow_step_lengths              : LineNo. 103  - Step name 'create_dummy_file_step' is greater than 21 characters
2022-10-31 10:31:09,893 - INFO     - zip_v2_workflow           - __call__                                 : LineNo. 148  - Zipping up workflow
2022-10-31 10:31:10,226 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/bclconvert-run-configuration/2.0.0--4.0.3/bclconvert-run-configuration__2.0.0--4.0.3.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:10,307 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/fastq-list-row/1.0.0/fastq-list-row__1.0.0.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:10,644 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/bclconvert-run-configuration/2.0.0--4.0.3/bclconvert-run-configuration__2.0.0--4.0.3.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:10,709 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/fastq-list-row/1.0.0/fastq-list-row__1.0.0.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:11,055 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/samplesheet/2.0.0--4.0.3/samplesheet__2.0.0--4.0.3.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:11,097 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/fastq-list-row/1.0.0/fastq-list-row__1.0.0.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:11,507 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/bclconvert-run-configuration/2.0.0--4.0.3/bclconvert-run-configuration__2.0.0--4.0.3.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:11,908 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/samplesheet/2.0.0--4.0.3/samplesheet__2.0.0--4.0.3.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:12,722 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/bclconvert-run-configuration/2.0.0--4.0.3/bclconvert-run-configuration__2.0.0--4.0.3.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:12,782 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/fastq-list-row/1.0.0/fastq-list-row__1.0.0.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:13,176 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/samplesheet/2.0.0--4.0.3/samplesheet__2.0.0--4.0.3.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:13,216 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/fastq-list-row/1.0.0/fastq-list-row__1.0.0.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:13,917 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/fastq-list-row/1.0.0/fastq-list-row__1.0.0.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:14,053 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/bclconvert-run-configuration/2.0.0--4.0.3/bclconvert-run-configuration__2.0.0--4.0.3.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:14,968 - INFO     - zip_v2_workflow           - zip_workflow                             : LineNo. 169  - Transferring files over into /c/Users/awluc/OneDrive/GitHub/UMCCR/cwl-ica/bclconvert-with-qc-pipeline__4.0.3
2022-10-31 10:31:31,991 - INFO     - zip_v2_workflow           - zip_workflow                             : LineNo. 242  - Finding steps names with lengths greater than 23 characters
2022-10-31 10:31:32,124 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/bclconvert-run-configuration/2.0.0--4.0.3/bclconvert-run-configuration__2.0.0--4.0.3.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:32,178 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/fastq-list-row/1.0.0/fastq-list-row__1.0.0.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:32,397 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/bclconvert-run-configuration/2.0.0--4.0.3/bclconvert-run-configuration__2.0.0--4.0.3.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:32,443 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/fastq-list-row/1.0.0/fastq-list-row__1.0.0.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:32,585 - WARNING  - cwl_workflow_helper_utils - check_workflow_step_lengths              : LineNo. 103  - Step name 'bcl_convert_samplesheet_check_scatter_step' is greater than 21 characters
2022-10-31 10:31:32,585 - WARNING  - cwl_workflow_helper_utils - check_workflow_step_lengths              : LineNo. 103  - Step name 'bcl_convert_scatter_step' is greater than 21 characters
2022-10-31 10:31:32,585 - WARNING  - cwl_workflow_helper_utils - check_workflow_step_lengths              : LineNo. 103  - Step name 'flatten_fastq_list_rows_array_step' is greater than 21 characters
2022-10-31 10:31:32,585 - WARNING  - cwl_workflow_helper_utils - check_workflow_step_lengths              : LineNo. 103  - Step name 'get_bcl_convert_run_configuration_object_step' is greater than 21 characters
2022-10-31 10:31:32,662 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/bclconvert-run-configuration/2.0.0--4.0.3/bclconvert-run-configuration__2.0.0--4.0.3.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:32,708 - INFO     - cwl                       - import_cwl_yaml                          : LineNo. 131  - Manually adding in "../../../schemas/fastq-list-row/1.0.0/fastq-list-row__1.0.0.yaml" into namespaces before we import the cwl object
2022-10-31 10:31:32,867 - WARNING  - cwl_workflow_helper_utils - check_workflow_step_lengths              : LineNo. 103  - Step name 'bcl_convert_samplesheet_check_step' is greater than 21 characters
2022-10-31 10:31:32,867 - WARNING  - cwl_workflow_helper_utils - check_workflow_step_lengths              : LineNo. 103  - Step name 'create_dummy_directory_step' is greater than 21 characters
2022-10-31 10:31:32,867 - WARNING  - cwl_workflow_helper_utils - check_workflow_step_lengths              : LineNo. 103  - Step name 'get_bcl_convert_run_configuration_object_step' is greater than 21 characters
2022-10-31 10:31:32,867 - WARNING  - cwl_workflow_helper_utils - check_workflow_step_lengths              : LineNo. 103  - Step name 'get_run_info_file_from_directory_expression_step' is greater than 21 characters
2022-10-31 10:31:32,868 - WARNING  - cwl_workflow_helper_utils - check_workflow_step_lengths              : LineNo. 103  - Step name 'get_samplesheet_file_from_directory_expression_step' is greater than 21 characters
2022-10-31 10:31:32,868 - INFO     - zip_v2_workflow           - zip_workflow                             : LineNo. 258  - Now all files have been transferred, confirming successful 'zip' with cwltool --validate
```