### PR TITLE
ilmn-tes namespace requires https not http

### DIFF
--- a/classes/cwl_tool.py
+++ b/classes/cwl_tool.py
@@ -219,7 +219,7 @@ class CWLTool(CWL):
                 schemas=["https://schema.org/version/latest/schemaorg-current-http.rdf"],
                 namespaces={
                     "s": "https://schema.org/",
-                    "ilmn-tes": "http://platform.illumina.com/rdf/ica/"
+                    "ilmn-tes": "https://platform.illumina.com/rdf/ica/"
                 }
             ),
             successCodes=[0]


### PR DESCRIPTION
Related issues

* https://github.com/umccr/cwl-ica/issues/204
* https://github.com/umccr-illumina/cwl-iap/issues/189#issuecomment-1369404594

Doesn't resolve them, just means new tools won't have this issue.