### PR TITLE
Fix releases url

### DIFF
--- a/subcommands/github_actions/build_workflow_release_assets.py
+++ b/subcommands/github_actions/build_workflow_release_assets.py
@@ -239,7 +239,7 @@ Environment Variables
         """
 
     def get_release_url(self):
-        return get_releases_url() + self.release_name
+        return get_releases_url() + self.github_tag[1]
 
     def create_markdown_file_object(self):
         self.initialise_markdown_file()


### PR DESCRIPTION
releases url still has a '/' for the tag, use github tag over release name when collecting the release url.  

Resolves #125