### PR TITLE
Update mapping logic to cater for icav1 and icav2 discrepancies in resource requirements

### DIFF
--- a/utils/cwl_workflow_helper_utils.py
+++ b/utils/cwl_workflow_helper_utils.py
@@ -295,10 +295,10 @@ def zip_workflow(cwl_obj: CWLWorkflow, output_zip_path: Path):
                         )
 
                 if path_item_cwl_obj is not None:
-                    if path_item_cwl_obj.hints is None:
-                        continue
                     # Deal with https://github.com/umccr-illumina/ica_v2/issues/128
                     for resource_mapping in ICAV2_COMPUTE_RESOURCE_STANDARD_SIZE_MAPPINGS:
+                        if path_item_cwl_obj.hints is None:
+                            continue
                         for hint in path_item_cwl_obj.hints:
                             if isinstance(hint, ResourceRequirementType) and \
                                     hint.extension_fields is not None and \
@@ -311,6 +311,8 @@ def zip_workflow(cwl_obj: CWLWorkflow, output_zip_path: Path):
                                     )
                     # Deal with https://github.com/umccr-illumina/ica_v2/issues/108
                     for resource_mapping in ICAV2_COMPUTE_RESOURCE_TYPE_MAPPINGS:
+                        if path_item_cwl_obj.hints is None:
+                            continue
                         for hint in path_item_cwl_obj.hints:
                             if isinstance(hint, ResourceRequirementType) and \
                                     hint.extension_fields is not None and \
@@ -323,6 +325,8 @@ def zip_workflow(cwl_obj: CWLWorkflow, output_zip_path: Path):
                                 )
                     # Deal with https://github.com/umccr-illumina/dragen/issues/48
                     for container_mapping in ICAV2_CONTAINER_MAPPINGS:
+                        if path_item_cwl_obj.requirements is None:
+                            continue
                         for requirement in path_item_cwl_obj.requirements:
                             if isinstance(requirement, DockerRequirementType) and \
                                     requirement.dockerPull == resource_mapping.get("v1"):

--- a/utils/globals.py
+++ b/utils/globals.py
@@ -141,14 +141,33 @@ ICA_TES_INSTANCE_SIZES_BY_TYPE = {
 ICAV1_CWLTOOL_VERSION = "3.0.20201203173111"
 ICAV1_CWLTOOL_CONDA_ENV_NAME = "cwltool-icav1"
 
-ICAV2_COMPUTE_RESOURCE_MAPPINGS = [
+ICAV2_COMPUTE_RESOURCE_TYPE_MAPPINGS = [
     {
-        "v1": "type: standardHiCpu",
-        "v2": "type: hicpu"
+        "v1": "ilmn-tes:resources/type: standardHiCpu",
+        "v2": "ilmn-tes:resources/type: hicpu"
     },
     {
-        "v1": "type: standardHiMem",
-        "v2": "type: himem"
+        "v1": "ilmn-tes:resources/type: standardHiMem",
+        "v2": "ilmn-tes:resources/type: himem"
+    }
+]
+
+ICAV2_COMPUTE_RESOURCE_STANDARD_SIZE_MAPPINGS = [
+    {
+        "v1": "ilmn-tes:resources/size: medium",
+        "v2": "ilmn-tes:resources/size: small"
+    },
+    {
+        "v1": "ilmn-tes:resources/size: large",
+        "v2": "ilmn-tes:resources/size: small"
+    },
+    {
+        "v1": "ilmn-tes:resources/size: xlarge",
+        "v2": "ilmn-tes:resources/size: medium"
+    },
+    {
+        "v1": "ilmn-tes:resources/size: xxlarge",
+        "v2": "ilmn-tes:resources/size: large"
     }
 ]
 


### PR DESCRIPTION
Fix mappings between resources sizes between icav1 and icav2 for standard compute types - see https://github.com/umccr-illumina/ica_v2/issues/128 for more information.