### PR TITLE
Release prod workflows and allow failed sync github actions to rerun if prod workflow versions are created

### DIFF
--- a/classes/ica_workflow.py
+++ b/classes/ica_workflow.py
@@ -14,6 +14,9 @@ ICAWorkflow has the following properties
     * The modification time of the ICA workflow version
     * Any run instances associated with this ICAWorkflowVersion
 """
+from typing import List
+
+from libica.openapi.libwes import WorkflowVersionCompact
 
 from classes.ica_workflow_version import ICAWorkflowVersion
 from pathlib import Path
@@ -193,6 +196,29 @@ class ICAWorkflow:
                              f"update workflow \"{self.ica_workflow_id}\"")
 
         self.workflow_obj = api_response
+
+    def list_workflow_versions(self, access_token) -> List[WorkflowVersionCompact]:
+        """
+        List workflow versions
+        :return:
+        """
+
+        # Set config
+        configuration = self.get_ica_wes_configuration(access_token)
+
+        # Create a project token
+        with libica.openapi.libwes.ApiClient(configuration) as api_client:
+            # Create an instance of the API class
+            api_instance = libica.openapi.libwes.WorkflowVersionsApi(api_client)
+
+            try:
+                # Get the details of a workflow version
+                api_response = api_instance.list_workflow_versions(self.ica_workflow_id)
+            except ApiException:
+                logger.error(f"Api exeception error when trying to "
+                             f"update workflow \"{self.ica_workflow_id}\"")
+
+        return api_response.items
 
     @classmethod
     def from_dict(cls, workflow_dict):

--- a/classes/ica_workflow_version.py
+++ b/classes/ica_workflow_version.py
@@ -68,7 +68,7 @@ class ICAWorkflowVersion:
         )
         return configuration
 
-    def create_workflow_version(self, workflow_definition, access_token, project_id, linked_projects):
+    def create_workflow_version(self, workflow_definition, access_token, project_id, linked_projects, status="draft"):
         """
         Use libica to create a workflow version though POST
         :return:
@@ -90,7 +90,8 @@ class ICAWorkflowVersion:
             body = libica.openapi.libwes.CreateWorkflowVersionRequest(version=self.ica_workflow_version_name,
                                                                       definition=workflow_definition,
                                                                       language=language,
-                                                                      acl=acl)
+                                                                      acl=acl,
+                                                                      status=status)
 
             try:
                 # Create a new workflow version


### PR DESCRIPTION
Also added in list_workflow_versions method to ica workflow class

Check if ica workflow version exists in production first before trying to build it

Add status keyword parameter to create_workflow_version method of icaworkflowversion class, set to 'draft' by default but set to released for workflow versions used in production projects.

Resolves https://github.com/umccr/cwl-ica-cli/issues/149,  https://github.com/umccr/cwl-ica-cli/issues/150 and https://github.com/umccr/cwl-ica-cli/issues/152

