### PR TITLE
Import and naming fixes

### DIFF
--- a/classes/icav2_bunch_classes.py
+++ b/classes/icav2_bunch_classes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections import OrderedDict
 from pathlib import Path
 from typing import Optional, List, Dict
@@ -872,7 +873,9 @@ class BunchVersion:
 
         name, version = get_name_version_tuple_from_cwl_file_path(abs_pipeline_path, workflows_path)
 
-        version_suffix = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        # Just get the timestamp from the version suffix
+        # dragen-somatic-with-germline-pipeline/4.2.4__20231025233121
+        version_suffix = os.environ["GITHUB_TAG"].split(",")[-1].rsplit("__", 1)[-1]
 
         bundle_obj = Bundle(
             create=True,

--- a/subcommands/github_actions/build_workflow_release_assets.py
+++ b/subcommands/github_actions/build_workflow_release_assets.py
@@ -46,7 +46,7 @@ from classes.icav2_bunch_classes import Bunch, BunchVersion, Bundle
 from utils.cwl_helper_utils import create_template_from_workflow_inputs, create_template_from_workflow_outputs, \
     get_workflow_overrides_steps_dict, get_type_from_cwl_io_object
 from utils.cwl_workflow_helper_utils import zip_workflow, create_packed_workflow_from_zipped_workflow_path
-from utils.dockstore_helpers import append_workflow_to_dockstore_yaml, get_dockstore_yaml_path
+from utils.dockstore_helpers import append_workflow_to_dockstore_yaml, get_dockstore_yaml_path, workflow_path_name_to_dockstore_name
 from utils.gh_helpers import get_gh_release_output_path, get_github_url, get_releases_url
 from utils.globals import ICAV2_DEFAULT_BASE_URL
 from utils.icav2_gh_helpers import read_config_yaml, write_config_yaml, get_icav2_config_yaml_path, \


### PR DESCRIPTION
Need to import workflow_path_name_to_dockstore_name function

Get version suffix from github for bundles instead.

Resolves #229 
Resolves #230 