### PR TITLE
Add overrides and inputs as release assets

### DIFF
--- a/src/cwl_ica/classes/cwl.py
+++ b/src/cwl_ica/classes/cwl.py
@@ -226,7 +226,7 @@ class CWL:
                 [
                     "conda", "run",
                     "--name", ICAV1_CWLTOOL_CONDA_ENV_NAME,
-                    "cwltool", "--no-doc-cache", "--validate", cwl_file_path
+                    "cwltool", "--no-doc-cache", "--validate", str(cwl_file_path)
 
                 ],
                 capture_output=True)


### PR DESCRIPTION
This will mean the icav2 cli plugins repo will not need to scrape the release page in order to generate an inputs template.

Also added the header yaml-language-server to the inputs json of the inputs template.

Resolves #277 