### PR TITLE
Allow validation to skip validation of packed object (valid for zipped wfls)

### DIFF
--- a/src/cwl_ica/classes/cwl_workflow.py
+++ b/src/cwl_ica/classes/cwl_workflow.py
@@ -51,7 +51,7 @@ class CWLWorkflow(CWL):
         if Path(self.temp_packed_file).is_file():
             os.remove(self.temp_packed_file)
 
-    def validate_object(self):
+    def validate_object(self, skip_packed=False):
         """
         Validate a cwl workflow
 
@@ -144,6 +144,12 @@ class CWLWorkflow(CWL):
 
         # Run cwltool --validate
         self.run_cwltool_validate(self.cwl_file_path)
+
+        # Skip packing
+        if skip_packed:
+            if not validation_passing:
+                logger.error(f"There were a total of {issue_count} issues.")
+                raise CWLValidationError
 
         # Pack workflow
         self.temp_packed_file = NamedTemporaryFile(

--- a/src/cwl_ica/subcommands/github_actions/build_workflow_release_assets.py
+++ b/src/cwl_ica/subcommands/github_actions/build_workflow_release_assets.py
@@ -843,9 +843,13 @@ Environment Variables
                 name=name,
                 version=version)
             workflow_obj(validate=False)
-            workflow_obj.generate_workflow_image(
-                workflow_image_path
-            )
+            try:
+                workflow_obj.generate_workflow_image(
+                    workflow_image_path
+                )
+            except Exception as e:
+                logger.error(f"Could not generate image for {workflow_image_path} - {e}")
+                continue
             workflow_paths.append(
                 (workflow.name, workflow_image_path, workflow_image_url)
             )

--- a/src/cwl_ica/subcommands/v2/zip_v2_workflow.py
+++ b/src/cwl_ica/subcommands/v2/zip_v2_workflow.py
@@ -138,7 +138,7 @@ Example:
 
     def __call__(self):
         logger.info("Validating workflow before copying over files")
-        self.cwl_workflow_obj.validate_object()
+        self.cwl_workflow_obj.validate_object(skip_packed=True)
 
         logger.info("Ensuring workflow does not have steps with names greater than 21 characters")
         check_workflow_step_lengths(self.cwl_workflow_obj.cwl_obj, self.cwl_file_path)


### PR DESCRIPTION
Allow build release assets to try but also fail building images for subworkflows